### PR TITLE
Sort constant model parameters by mean

### DIFF
--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -70,6 +70,10 @@ class TissueClassifierHMRF(object):
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
         mu, sigma = com.seg_stats(image, seg_init, nclasses)
+        # Sort models
+        p = np.argsort(mu)
+        mu = mu[p]
+        sigma = sigma[p]
         sigmasq = sigma ** 2
 
         zero = np.zeros_like(image) + 0.001
@@ -89,6 +93,9 @@ class TissueClassifierHMRF(object):
             PVE = com.prob_image(image_gauss, nclasses, mu, sigmasq, PLN)
             mu_upd, sigmasq_upd = com.update_param(image_gauss, PVE, mu,
                                                    nclasses)
+            p = np.argsort(mu_upd)
+            mu_upd = mu_upd[p]
+            sigmasq_upd = sigmasq_upd[p]
 
             negll = com.negloglikelihood(image_gauss,
                                          mu_upd, sigmasq_upd, nclasses)


### PR DESCRIPTION
This is a very simple fix to make sure the mean intensities are sorted. The following graph depicts the Jaccard scores as a function of beta after applying this fix.
![sorted_labels](https://cloud.githubusercontent.com/assets/1608583/16350996/3b71a7b8-3a17-11e6-899f-d3b6a4ddc553.png)
